### PR TITLE
Nickname beim senden verwenden

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ class MQTTChatGUI(Frame):
         self.send_button = ttk.Button(frm, text="Send")
         self.send_button.grid(column=4, row=2, sticky="e")
         self.send_button.config(command=self.send_message)
-        self.scrollbar = ttk.Scrollbar(root, orient='vertical', command=self.main_text.yview)
+        self.scrollbar = ttk.Scrollbar(self.root, orient='vertical', command=self.main_text.yview)
         self.scrollbar.grid(row=0, column=1, sticky='ns')
         self.main_text.config(yscrollcommand=self.scrollbar.set)
 

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ class MQTTChatGUI(Frame):
         self.mqtt_client.subscribe("/BWI20KS/Chat", 1)
 
     def send_message(self, event=None):
-        message = self.message_entry.get()
+        message = self.broker_entry.get() + ": " + self.message_entry.get()
         # Delete entry in message field after sending
         self.message_entry.delete(0, END)
         # publish message after send, QoS1


### PR DESCRIPTION
Der Inhalt des oberen Eingabefelds wird als "Nickname" verwendet und jeder Sendung vorangestellt.

Nickname: Message